### PR TITLE
Fixed LoadImageAnim frames argument.

### DIFF
--- a/Raylib-cs/types/Raylib.Utils.cs
+++ b/Raylib-cs/types/Raylib.Utils.cs
@@ -106,10 +106,10 @@ namespace Raylib_cs
         }
 
         /// <summary>Load image sequence from file (frames appended to image.data)</summary>
-        public static Image LoadImageAnim(string fileName, int[] frames)
+        public static Image LoadImageAnim(string fileName, out int frames)
         {
             using var str1 = fileName.ToUTF8Buffer();
-            fixed (int* p = frames)
+            fixed (int* p = &frames)
             {
                 return LoadImageAnim(str1.AsPointer(), p);
             }


### PR DESCRIPTION
Changed the frames argument in LoadImageAnim to be a out parameter.

According to Ray, frames should have the number of frames in the animation and using a out parameter seems to be correct way in C#.

I also implemented the example textures_gif_player to test it. I will do a PR when the examples get updated with the new package.