### PR TITLE
Added some help info for NuGet use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ dotnet add package Raylib-cs --version 4.2.0.2
 
 If you need to edit Raylib-cs source then you will need to add the bindings as a project (see below).
 
+If you are new to using NuGet (or you've forgotten) and are trying to run the above command in the command prompt, remember that you need to be *inside the intended project directory* (not just inside the solution directory) otherwise the command won't work.
+
 ## Installation - Manual
 
 1. Download/Clone this repo


### PR DESCRIPTION
I accidentally made the mistake of trying to use NuGet in the solution folder and it took a few minutes to figure out what I was doing wrong.

So, I added this sentence here to help clarify what to do for this (probably common) problem since Visual Studio is fairly likely to start the working directory for the command prompt in the solution directory, which may not be the same as the project directory. 

I think since raylib attracts many new users it is best to make the install info as easy as possible, thus my justification for adding this here. 

Installs should be as frictionless as possible. I hope you'll consider adding my suggestion here. 🙂