### PR TITLE
Add managed methods for updating textures

### DIFF
--- a/Raylib-cs.sln
+++ b/Raylib-cs.sln
@@ -1,4 +1,4 @@
-﻿﻿
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27703.2035

--- a/Raylib-cs.sln
+++ b/Raylib-cs.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2035
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33829.357
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raylib-cs", "Raylib-cs\Raylib-cs.csproj", "{B02C431E-271A-432E-BA5C-EE3B68DBF585}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Raylib-cs", "Raylib-cs\Raylib-cs.csproj", "{B02C431E-271A-432E-BA5C-EE3B68DBF585}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Raylib-cs.Tests", "Raylib-cs.Tests\Raylib-cs.Tests.csproj", "{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}"
 EndProject
@@ -17,14 +17,30 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|x64.Build.0 = Debug|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|x86.Build.0 = Debug|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|x64.ActiveCfg = Release|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|x64.Build.0 = Release|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|x86.ActiveCfg = Release|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|x86.Build.0 = Release|Any CPU
 		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|x64.Build.0 = Debug|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|x86.Build.0 = Debug|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|x64.ActiveCfg = Release|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|x64.Build.0 = Release|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|x86.ActiveCfg = Release|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Raylib-cs.sln
+++ b/Raylib-cs.sln
@@ -1,9 +1,9 @@
-﻿
+﻿﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.6.33829.357
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2035
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Raylib-cs", "Raylib-cs\Raylib-cs.csproj", "{B02C431E-271A-432E-BA5C-EE3B68DBF585}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raylib-cs", "Raylib-cs\Raylib-cs.csproj", "{B02C431E-271A-432E-BA5C-EE3B68DBF585}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Raylib-cs.Tests", "Raylib-cs.Tests\Raylib-cs.Tests.csproj", "{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}"
 EndProject
@@ -17,30 +17,14 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|x64.Build.0 = Debug|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|x86.Build.0 = Debug|Any CPU
 		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|x64.ActiveCfg = Release|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|x64.Build.0 = Release|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|x86.ActiveCfg = Release|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|x86.Build.0 = Release|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|x64.Build.0 = Debug|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|x86.Build.0 = Debug|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|x64.ActiveCfg = Release|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|x64.Build.0 = Release|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|x86.ActiveCfg = Release|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|x86.Build.0 = Release|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Raylib-cs/types/Raylib.Utils.cs
+++ b/Raylib-cs/types/Raylib.Utils.cs
@@ -652,6 +652,36 @@ namespace Raylib_cs
             return LoadTexture(str1.AsPointer());
         }
 
+        /// <summary>Update GPU texture with new data</summary>
+        public static void UpdateTexture<T>(Texture2D texture, T[] pixels) where T : unmanaged
+        {
+            UpdateTexture(texture, (ReadOnlySpan<T>)pixels);
+        }
+
+        /// <summary>Update GPU texture with new data</summary>
+        public static void UpdateTexture<T>(Texture2D texture, ReadOnlySpan<T> pixels) where T : unmanaged
+        {
+            fixed (void* pixelPtr = pixels)
+            {
+                UpdateTexture(texture, pixelPtr);
+            }
+        }
+
+        /// <summary>Update GPU texture rectangle with new data</summary>
+        public static void UpdateTextureRec<T>(Texture2D texture, Rectangle rec, T[] pixels) where T : unmanaged
+        {
+            UpdateTextureRec(texture, rec, (ReadOnlySpan<T>)pixels);
+        }
+
+        /// <summary>Update GPU texture rectangle with new data</summary>
+        public static void UpdateTextureRec<T>(Texture2D texture, Rectangle rec, ReadOnlySpan<T> pixels) where T : unmanaged
+        {
+            fixed (void* pixelPtr = pixels)
+            {
+                UpdateTextureRec(texture, rec, pixelPtr);
+            }
+        }
+
         /// <summary>Generate GPU mipmaps for a texture</summary>
         public static void GenTextureMipmaps(ref Texture2D texture)
         {


### PR DESCRIPTION
Adding the four following method overloads will make unsafe code blocks unnecessary for fast texture updates.