### PR TITLE
Fix linux build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,8 @@ jobs:
     steps:
       - name: setup dependencies
         run: |
-          sudo apt install \
+          sudo apt-get update
+          sudo apt-get install \
             libasound2-dev \
             libx11-dev \
             libxrandr-dev \


### PR DESCRIPTION
based on https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners
> **Note:** Always run `sudo apt-get update` before installing a package. In case the `apt` index is stale, this command fetches and re-indexes any available packages, which helps prevent package installation failures.

this should fix ci failing when building linux on #181 and #171 