### PR TITLE
[Fix #184] Seperate UTF8 from Ansi

### DIFF
--- a/Raylib-cs.sln
+++ b/Raylib-cs.sln
@@ -1,4 +1,4 @@
-﻿﻿
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27703.2035

--- a/Raylib-cs.sln
+++ b/Raylib-cs.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2035
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33829.357
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raylib-cs", "Raylib-cs\Raylib-cs.csproj", "{B02C431E-271A-432E-BA5C-EE3B68DBF585}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Raylib-cs", "Raylib-cs\Raylib-cs.csproj", "{B02C431E-271A-432E-BA5C-EE3B68DBF585}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Raylib-cs.Tests", "Raylib-cs.Tests\Raylib-cs.Tests.csproj", "{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}"
 EndProject
@@ -17,14 +17,30 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|x64.Build.0 = Debug|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|x86.Build.0 = Debug|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|x64.ActiveCfg = Release|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|x64.Build.0 = Release|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|x86.ActiveCfg = Release|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|x86.Build.0 = Release|Any CPU
 		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|x64.Build.0 = Debug|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|x86.Build.0 = Debug|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|x64.ActiveCfg = Release|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|x64.Build.0 = Release|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|x86.ActiveCfg = Release|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Raylib-cs.sln
+++ b/Raylib-cs.sln
@@ -1,9 +1,9 @@
-﻿
+﻿﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.6.33829.357
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2035
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Raylib-cs", "Raylib-cs\Raylib-cs.csproj", "{B02C431E-271A-432E-BA5C-EE3B68DBF585}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raylib-cs", "Raylib-cs\Raylib-cs.csproj", "{B02C431E-271A-432E-BA5C-EE3B68DBF585}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Raylib-cs.Tests", "Raylib-cs.Tests\Raylib-cs.Tests.csproj", "{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}"
 EndProject
@@ -17,30 +17,14 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|x64.Build.0 = Debug|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|x86.Build.0 = Debug|Any CPU
 		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|x64.ActiveCfg = Release|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|x64.Build.0 = Release|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|x86.ActiveCfg = Release|Any CPU
-		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Release|x86.Build.0 = Release|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|x64.Build.0 = Debug|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|x86.Build.0 = Debug|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B02C431E-271A-432E-BA5C-EE3B68DBF585}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|Any CPU.Build.0 = Release|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|x64.ActiveCfg = Release|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|x64.Build.0 = Release|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|x86.ActiveCfg = Release|Any CPU
-		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Release|x86.Build.0 = Release|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{523DEE6A-20CD-47AB-94A6-8D3C3CF9ADAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Raylib-cs/Raylib-cs.csproj
+++ b/Raylib-cs/Raylib-cs.csproj
@@ -1,60 +1,60 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFrameworks>net5.0;net6.0</TargetFrameworks>
-		<EnableDefaultItems>false</EnableDefaultItems>
-		<AssemblyName>Raylib-cs</AssemblyName>
-		<RootNamespace>Raylib_cs</RootNamespace>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-		<NoWarn>$(NoWarn);1591</NoWarn>
-		<LangVersion>10.0</LangVersion>
-	</PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <EnableDefaultItems>false</EnableDefaultItems>
+    <AssemblyName>Raylib-cs</AssemblyName>
+    <RootNamespace>Raylib_cs</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <LangVersion>10.0</LangVersion>
+  </PropertyGroup>
 
-	<PropertyGroup>
-		<TargetRaylibTag>4.5.0</TargetRaylibTag>
-		<Version>4.5.0.3</Version>
-		<PackageVersion>4.5.0.3</PackageVersion>
-		<Authors>Chris Dill, Raysan5</Authors>
-		<PackProject>true</PackProject>
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<PackageLicenseExpression>Zlib</PackageLicenseExpression>
-		<Title>Raylib-cs</Title>
-		<Description>C# bindings for raylib - A simple and easy-to-use library to learn videogames programming</Description>
-		<PackageIcon>raylib-cs_64x64.png</PackageIcon>
-		<PackageTags>raylib;bindings;gamedev</PackageTags>
-		<RepositoryType>git</RepositoryType>
-		<RepositoryUrl>https://github.com/ChrisDill/Raylib-cs/</RepositoryUrl>
-		<PublishRepositoryUrl>true</PublishRepositoryUrl>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageProjectUrl>https://www.raylib.com/</PackageProjectUrl>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetRaylibTag>4.5.0</TargetRaylibTag>
+    <Version>4.5.0.3</Version>
+    <PackageVersion>4.5.0.3</PackageVersion>
+    <Authors>Chris Dill, Raysan5</Authors>
+    <PackProject>true</PackProject>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageLicenseExpression>Zlib</PackageLicenseExpression>
+    <Title>Raylib-cs</Title>
+    <Description>C# bindings for raylib - A simple and easy-to-use library to learn videogames programming</Description>
+    <PackageIcon>raylib-cs_64x64.png</PackageIcon>
+    <PackageTags>raylib;bindings;gamedev</PackageTags>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/ChrisDill/Raylib-cs/</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageProjectUrl>https://www.raylib.com/</PackageProjectUrl>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<None Include="../Logo/raylib-cs_64x64.png" Pack="true" PackagePath="" />
-		<None Include="../README.md" Pack="true" PackagePath="" />
-	</ItemGroup>
+  <ItemGroup>
+    <None Include="../Logo/raylib-cs_64x64.png" Pack="true" PackagePath="" />
+    <None Include="../README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+  </ItemGroup>
 
-	<ItemGroup>
-		<Content Include="runtimes/**" Link="runtimes/%(RecursiveDir)/%(Filename)%(Extension)">
-			<PackagePath>runtimes/</PackagePath>
-			<Pack>true</Pack>
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-	</ItemGroup>
+  <ItemGroup>
+    <Content Include="runtimes/**" Link="runtimes/%(RecursiveDir)/%(Filename)%(Extension)">
+      <PackagePath>runtimes/</PackagePath>
+      <Pack>true</Pack>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 
-	<ItemGroup>
-		<Compile Include="interop\*.cs" />
-		<Compile Include="types\*.cs" />
-		<Compile Include="types\native\CBool.cs" />
-        <Compile Include="types\native\AnsiBuffer.cs" />
-		<Compile Include="types\native\FilePathList.cs" />
-        <Compile Include="types\native\UTF8Buffer.cs" />
-	</ItemGroup>
+  <ItemGroup>
+    <Compile Include="interop\*.cs" />
+    <Compile Include="types\*.cs" />
+    <Compile Include="types\native\CBool.cs" />
+	<Compile Include="types\native\AnsiBuffer.cs" />
+    <Compile Include="types\native\UTF8Buffer.cs" />
+    <Compile Include="types\native\FilePathList.cs" />
+  </ItemGroup>
 </Project>

--- a/Raylib-cs/Raylib-cs.csproj
+++ b/Raylib-cs/Raylib-cs.csproj
@@ -53,7 +53,7 @@
     <Compile Include="interop\*.cs" />
     <Compile Include="types\*.cs" />
     <Compile Include="types\native\CBool.cs" />
-	<Compile Include="types\native\AnsiBuffer.cs" />
+    <Compile Include="types\native\AnsiBuffer.cs" />
     <Compile Include="types\native\UTF8Buffer.cs" />
     <Compile Include="types\native\FilePathList.cs" />
   </ItemGroup>

--- a/Raylib-cs/Raylib-cs.csproj
+++ b/Raylib-cs/Raylib-cs.csproj
@@ -1,60 +1,60 @@
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
-    <EnableDefaultItems>false</EnableDefaultItems>
-    <AssemblyName>Raylib-cs</AssemblyName>
-    <RootNamespace>Raylib_cs</RootNamespace>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <NoWarn>$(NoWarn);1591</NoWarn>
-    <LangVersion>10.0</LangVersion>
-  </PropertyGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+		<EnableDefaultItems>false</EnableDefaultItems>
+		<AssemblyName>Raylib-cs</AssemblyName>
+		<RootNamespace>Raylib_cs</RootNamespace>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+		<NoWarn>$(NoWarn);1591</NoWarn>
+		<LangVersion>10.0</LangVersion>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <TargetRaylibTag>4.5.0</TargetRaylibTag>
-    <Version>4.5.0.3</Version>
-    <PackageVersion>4.5.0.3</PackageVersion>
-    <Authors>Chris Dill, Raysan5</Authors>
-    <PackProject>true</PackProject>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageLicenseExpression>Zlib</PackageLicenseExpression>
-    <Title>Raylib-cs</Title>
-    <Description>C# bindings for raylib - A simple and easy-to-use library to learn videogames programming</Description>
-    <PackageIcon>raylib-cs_64x64.png</PackageIcon>
-    <PackageTags>raylib;bindings;gamedev</PackageTags>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/ChrisDill/Raylib-cs/</RepositoryUrl>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageProjectUrl>https://www.raylib.com/</PackageProjectUrl>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetRaylibTag>4.5.0</TargetRaylibTag>
+		<Version>4.5.0.3</Version>
+		<PackageVersion>4.5.0.3</PackageVersion>
+		<Authors>Chris Dill, Raysan5</Authors>
+		<PackProject>true</PackProject>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<PackageLicenseExpression>Zlib</PackageLicenseExpression>
+		<Title>Raylib-cs</Title>
+		<Description>C# bindings for raylib - A simple and easy-to-use library to learn videogames programming</Description>
+		<PackageIcon>raylib-cs_64x64.png</PackageIcon>
+		<PackageTags>raylib;bindings;gamedev</PackageTags>
+		<RepositoryType>git</RepositoryType>
+		<RepositoryUrl>https://github.com/ChrisDill/Raylib-cs/</RepositoryUrl>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageProjectUrl>https://www.raylib.com/</PackageProjectUrl>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="../Logo/raylib-cs_64x64.png" Pack="true" PackagePath="" />
-    <None Include="../README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="../Logo/raylib-cs_64x64.png" Pack="true" PackagePath="" />
+		<None Include="../README.md" Pack="true" PackagePath="" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+	</ItemGroup>
 
-  <ItemGroup>
-    <Content Include="runtimes/**" Link="runtimes/%(RecursiveDir)/%(Filename)%(Extension)">
-      <PackagePath>runtimes/</PackagePath>
-      <Pack>true</Pack>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<Content Include="runtimes/**" Link="runtimes/%(RecursiveDir)/%(Filename)%(Extension)">
+			<PackagePath>runtimes/</PackagePath>
+			<Pack>true</Pack>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="interop\*.cs" />
-    <Compile Include="types\*.cs" />
-    <Compile Include="types\native\CBool.cs" />
-    <Compile Include="types\native\AnsiBuffer.cs" />
-    <Compile Include="types\native\FilePathList.cs" />
-    <Compile Include="types\native\UTF8Buffer.cs" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Include="interop\*.cs" />
+		<Compile Include="types\*.cs" />
+		<Compile Include="types\native\CBool.cs" />
+        <Compile Include="types\native\AnsiBuffer.cs" />
+		<Compile Include="types\native\FilePathList.cs" />
+        <Compile Include="types\native\UTF8Buffer.cs" />
+	</ItemGroup>
 </Project>

--- a/Raylib-cs/Raylib-cs.csproj
+++ b/Raylib-cs/Raylib-cs.csproj
@@ -38,7 +38,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
@@ -53,7 +53,8 @@
     <Compile Include="interop\*.cs" />
     <Compile Include="types\*.cs" />
     <Compile Include="types\native\CBool.cs" />
-    <Compile Include="types\native\UTF8Buffer.cs" />
+    <Compile Include="types\native\AnsiBuffer.cs" />
     <Compile Include="types\native\FilePathList.cs" />
+    <Compile Include="types\native\UTF8Buffer.cs" />
   </ItemGroup>
 </Project>

--- a/Raylib-cs/types/Raylib.Utils.cs
+++ b/Raylib-cs/types/Raylib.Utils.cs
@@ -9,14 +9,14 @@ namespace Raylib_cs
         /// <summary>Initialize window and OpenGL context</summary>
         public static void InitWindow(int width, int height, string title)
         {
-            using var str1 = title.ToAnsiBuffer();
+            using var str1 = title.ToUTF8Buffer();
             InitWindow(width, height, str1.AsPointer());
         }
 
         /// <summary>Set title for window (only PLATFORM_DESKTOP)</summary>
         public static void SetWindowTitle(string title)
         {
-            using var str1 = title.ToAnsiBuffer();
+            using var str1 = title.ToUTF8Buffer();
             SetWindowTitle(str1.AsPointer());
         }
 
@@ -35,7 +35,7 @@ namespace Raylib_cs
         /// <summary>Set clipboard text content</summary>
         public static void SetClipboardText(string text)
         {
-            using var str1 = text.ToAnsiBuffer();
+            using var str1 = text.ToUTF8Buffer();
             SetClipboardText(str1.AsPointer());
         }
         
@@ -64,22 +64,22 @@ namespace Raylib_cs
         /// <summary>Load shader from code string and bind default locations</summary>
         public static Shader LoadShaderFromMemory(string vsCode, string fsCode)
         {
-            using var str1 = vsCode.ToAnsiBuffer();
-            using var str2 = fsCode.ToAnsiBuffer();
+            using var str1 = vsCode.ToUTF8Buffer();
+            using var str2 = fsCode.ToUTF8Buffer();
             return LoadShaderFromMemory(str1.AsPointer(), str2.AsPointer());
         }
 
         /// <summary>Get shader uniform location</summary>
         public static int GetShaderLocation(Shader shader, string uniformName)
         {
-            using var str1 = uniformName.ToAnsiBuffer();
+            using var str1 = uniformName.ToUTF8Buffer();
             return GetShaderLocation(shader, str1.AsPointer());
         }
 
         /// <summary>Get shader attribute location</summary>
         public static int GetShaderLocationAttrib(Shader shader, string attribName)
         {
-            using var str1 = attribName.ToAnsiBuffer();
+            using var str1 = attribName.ToUTF8Buffer();
             return GetShaderLocationAttrib(shader, str1.AsPointer());
         }
 

--- a/Raylib-cs/types/Raylib.Utils.cs
+++ b/Raylib-cs/types/Raylib.Utils.cs
@@ -9,14 +9,14 @@ namespace Raylib_cs
         /// <summary>Initialize window and OpenGL context</summary>
         public static void InitWindow(int width, int height, string title)
         {
-            using var str1 = title.ToUTF8Buffer();
+            using var str1 = title.ToAnsiBuffer();
             InitWindow(width, height, str1.AsPointer());
         }
 
         /// <summary>Set title for window (only PLATFORM_DESKTOP)</summary>
         public static void SetWindowTitle(string title)
         {
-            using var str1 = title.ToUTF8Buffer();
+            using var str1 = title.ToAnsiBuffer();
             SetWindowTitle(str1.AsPointer());
         }
 
@@ -35,7 +35,7 @@ namespace Raylib_cs
         /// <summary>Set clipboard text content</summary>
         public static void SetClipboardText(string text)
         {
-            using var str1 = text.ToUTF8Buffer();
+            using var str1 = text.ToAnsiBuffer();
             SetClipboardText(str1.AsPointer());
         }
         
@@ -56,73 +56,73 @@ namespace Raylib_cs
         /// <summary>Load shader from files and bind default locations</summary>
         public static Shader LoadShader(string vsFileName, string fsFileName)
         {
-            using var str1 = vsFileName.ToUTF8Buffer();
-            using var str2 = fsFileName.ToUTF8Buffer();
+            using var str1 = vsFileName.ToAnsiBuffer();
+            using var str2 = fsFileName.ToAnsiBuffer();
             return LoadShader(str1.AsPointer(), str2.AsPointer());
         }
 
         /// <summary>Load shader from code string and bind default locations</summary>
         public static Shader LoadShaderFromMemory(string vsCode, string fsCode)
         {
-            using var str1 = vsCode.ToUTF8Buffer();
-            using var str2 = fsCode.ToUTF8Buffer();
+            using var str1 = vsCode.ToAnsiBuffer();
+            using var str2 = fsCode.ToAnsiBuffer();
             return LoadShaderFromMemory(str1.AsPointer(), str2.AsPointer());
         }
 
         /// <summary>Get shader uniform location</summary>
         public static int GetShaderLocation(Shader shader, string uniformName)
         {
-            using var str1 = uniformName.ToUTF8Buffer();
+            using var str1 = uniformName.ToAnsiBuffer();
             return GetShaderLocation(shader, str1.AsPointer());
         }
 
         /// <summary>Get shader attribute location</summary>
         public static int GetShaderLocationAttrib(Shader shader, string attribName)
         {
-            using var str1 = attribName.ToUTF8Buffer();
+            using var str1 = attribName.ToAnsiBuffer();
             return GetShaderLocationAttrib(shader, str1.AsPointer());
         }
 
         /// <summary>Takes a screenshot of current screen (saved a .png)</summary>
         public static void TakeScreenshot(string fileName)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             TakeScreenshot(str1.AsPointer());
         }
 
         /// <summary>Check file extension</summary>
         public static CBool IsFileExtension(string fileName, string ext)
         {
-            using var str1 = fileName.ToUTF8Buffer();
-            using var str2 = ext.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
+            using var str2 = ext.ToAnsiBuffer();
             return IsFileExtension(str1.AsPointer(), str2.AsPointer());
         }
 
         /// <summary>Get file modification time (last write time)</summary>
         public static long GetFileModTime(string fileName)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             return GetFileModTime(str1.AsPointer());
         }
 
         /// <summary>Load image from file into CPU memory (RAM)</summary>
         public static Image LoadImage(string fileName)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             return LoadImage(str1.AsPointer());
         }
 
         /// <summary>Load image from RAW file data</summary>
         public static Image LoadImageRaw(string fileName, int width, int height, PixelFormat format, int headerSize)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             return LoadImageRaw(str1.AsPointer(), width, height, format, headerSize);
         }
 
         /// <summary>Load image sequence from file (frames appended to image.data)</summary>
         public static Image LoadImageAnim(string fileName, out int frames)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             fixed (int* p = &frames)
             {
                 return LoadImageAnim(str1.AsPointer(), p);
@@ -134,7 +134,7 @@ namespace Raylib_cs
         /// </summary>
         public static Image LoadImageFromMemory(string fileType, byte[] fileData)
         {
-            using var fileTypeNative = fileType.ToUTF8Buffer();
+            using var fileTypeNative = fileType.ToAnsiBuffer();
             fixed (byte* fileDataNative = fileData)
             {
                 Image image = LoadImageFromMemory(fileTypeNative.AsPointer(), fileDataNative, fileData.Length);
@@ -145,14 +145,14 @@ namespace Raylib_cs
         /// <summary>Export image data to file</summary>
         public static CBool ExportImage(Image image, string fileName)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             return ExportImage(image, str1.AsPointer());
         }
 
         /// <summary>Export image as code file defining an array of bytes</summary>
         public static CBool ExportImageAsCode(Image image, string fileName)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             return ExportImageAsCode(image, str1.AsPointer());
         }
 
@@ -225,7 +225,7 @@ namespace Raylib_cs
         /// <summary>Load file data as byte array (read)</summary>
         public static byte* LoadFileData(string fileName, ref uint bytesRead)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             fixed (uint* p = &bytesRead)
             {
                 return LoadFileData(str1.AsPointer(), p);
@@ -662,7 +662,7 @@ namespace Raylib_cs
         /// <summary>Load texture from file into GPU memory (VRAM)</summary>
         public static Texture2D LoadTexture(string fileName)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             return LoadTexture(str1.AsPointer());
         }
 
@@ -708,14 +708,14 @@ namespace Raylib_cs
         /// <summary>Load font from file into GPU memory (VRAM)</summary>
         public static Font LoadFont(string fileName)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             return LoadFont(str1.AsPointer());
         }
 
         /// <summary>Load font from file with extended parameters</summary>
         public static Font LoadFontEx(string fileName, int fontSize, int[] fontChars, int glyphCount)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             fixed (int* p = fontChars)
             {
                 return LoadFontEx(str1.AsPointer(), fontSize, p, glyphCount);
@@ -733,7 +733,7 @@ namespace Raylib_cs
             int glyphCount
         )
         {
-            using var fileTypeNative = fileType.ToUTF8Buffer();
+            using var fileTypeNative = fileType.ToAnsiBuffer();
             fixed (byte* fileDataNative = fileData)
             {
                 fixed (int* fontCharsNative = fontChars)
@@ -791,7 +791,7 @@ namespace Raylib_cs
         /// <summary>Load model animations from file</summary>
         public static ReadOnlySpan<ModelAnimation> LoadModelAnimations(string fileName, ref uint animCount)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             fixed (uint* p = &animCount)
             {
                 ModelAnimation* modelAnimations = LoadModelAnimations(str1.AsPointer(), p);
@@ -965,14 +965,14 @@ namespace Raylib_cs
         /// <summary>Draw a model (with texture if set)</summary>
         public static Model LoadModel(string fileName)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             return LoadModel(str1.AsPointer());
         }
 
         /// <summary>Export mesh data to file, returns true on success</summary>
         public static CBool ExportMesh(Mesh mesh, string fileName)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             return ExportMesh(mesh, str1.AsPointer());
         }
 
@@ -997,7 +997,7 @@ namespace Raylib_cs
         /// <summary>Load wave data from file</summary>
         public static Wave LoadWave(string fileName)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             return LoadWave(str1.AsPointer());
         }
 
@@ -1009,7 +1009,7 @@ namespace Raylib_cs
             byte[] fileData
         )
         {
-            using var fileTypeNative = fileType.ToUTF8Buffer();
+            using var fileTypeNative = fileType.ToAnsiBuffer();
 
             fixed (byte* fileDataNative = fileData)
             {
@@ -1026,28 +1026,28 @@ namespace Raylib_cs
         /// <summary>Load sound from file</summary>
         public static Sound LoadSound(string fileName)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             return LoadSound(str1.AsPointer());
         }
 
         /// <summary>Export wave data to file</summary>
         public static CBool ExportWave(Wave wave, string fileName)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             return ExportWave(wave, str1.AsPointer());
         }
 
         /// <summary>Export wave sample data to code (.h)</summary>
         public static CBool ExportWaveAsCode(Wave wave, string fileName)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             return ExportWaveAsCode(wave, str1.AsPointer());
         }
 
         /// <summary>Load music stream from file</summary>
         public static Music LoadMusicStream(string fileName)
         {
-            using var str1 = fileName.ToUTF8Buffer();
+            using var str1 = fileName.ToAnsiBuffer();
             return LoadMusicStream(str1.AsPointer());
         }
 
@@ -1059,7 +1059,7 @@ namespace Raylib_cs
             byte[] fileData
         )
         {
-            using var fileTypeNative = fileType.ToUTF8Buffer();
+            using var fileTypeNative = fileType.ToAnsiBuffer();
 
             fixed (byte* fileDataNative = fileData)
             {

--- a/Raylib-cs/types/native/AnsiBuffer.cs
+++ b/Raylib-cs/types/native/AnsiBuffer.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Raylib_cs
+{
+    /// <summary>
+    /// Converts text to a Ansi buffer for passing to native code
+    /// </summary>
+    public readonly ref struct AnsiBuffer
+    {
+        private readonly IntPtr data;
+
+        public AnsiBuffer(string text)
+        {
+            data = Marshal.StringToHGlobalAnsi(text);
+        }
+
+        public unsafe sbyte* AsPointer()
+        {
+            return (sbyte*)data.ToPointer();
+        }
+
+        public void Dispose()
+        {
+            Marshal.FreeHGlobal(data);
+        }
+    }
+
+    public static class AnsiStringUtils
+    {
+        public static AnsiBuffer ToAnsiBuffer(this string text)
+        {
+            return new AnsiBuffer(text);
+        }
+    }
+}

--- a/Raylib-cs/types/native/UTF8Buffer.cs
+++ b/Raylib-cs/types/native/UTF8Buffer.cs
@@ -1,19 +1,19 @@
-using System;
-using System.Text;
+﻿using System;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Raylib_cs
 {
     /// <summary>
     /// Converts text to a UTF8 buffer for passing to native code
     /// </summary>
-    public ref struct UTF8Buffer
+    public readonly ref struct UTF8Buffer
     {
-        private IntPtr data;
+        private readonly IntPtr data;
 
         public UTF8Buffer(string text)
         {
-            this.data = Marshal.StringToHGlobalAnsi(text);
+            data = Marshal.StringToCoTaskMemUTF8(text);
         }
 
         public unsafe sbyte* AsPointer()
@@ -23,7 +23,7 @@ namespace Raylib_cs
 
         public void Dispose()
         {
-            Marshal.FreeHGlobal(data);
+            Marshal.ZeroFreeCoTaskMemUTF8(data);
         }
     }
 


### PR DESCRIPTION
Fix for #184. The issue was that raylib text drawing functions do not use ansi - rather UTF8.

These changes should fix the issue by converting to the correct format depending on what each util method needs.