### PR TITLE
Update Desktop to OpenGL 4.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,7 @@ jobs:
             -D BUILD_EXAMPLES=OFF \
             -D CMAKE_C_FLAGS="${{ matrix.cflags }}" \
             -D GRAPHICS=GRAPHICS_API_OPENGL_43
-          cmake --build build --config Release
+          cmake --build build --config Release -Wno-dev
 
       - name: upload build
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,8 +159,7 @@ jobs:
             -D CMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} \
             -D BUILD_SHARED_LIBS=ON \
             -D BUILD_EXAMPLES=OFF \
-            -D CMAKE_C_FLAGS="${{ matrix.cflags }} -Wno-dev" \
-            -D CMAKE_CXX_FLAGS="${{ matrix.cflags }} -Wno-dev" \
+            -D CMAKE_C_FLAGS="${{ matrix.cflags }}" \
             -D GRAPHICS=GRAPHICS_API_OPENGL_43
           cmake --build build --config Release
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,9 +158,7 @@ jobs:
             -D CMAKE_BUILD_TYPE=Release \
             -D CMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} \
             -D BUILD_SHARED_LIBS=ON \
-            -D BUILD_EXAMPLES=OFF \
-            -D CMAKE_C_FLAGS="${{ matrix.cflags }}" \
-            -D GRAPHICS=GRAPHICS_API_OPENGL_43
+            -D BUILD_EXAMPLES=OFF
           cmake --build build --config Release
 
       - name: upload build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,9 @@ jobs:
             -B build \
             -D CMAKE_BUILD_TYPE=Release \
             -D BUILD_SHARED_LIBS=ON \
-            -D BUILD_EXAMPLES=OFF
+            -D BUILD_EXAMPLES=OFF \
+            -D CMAKE_C_FLAGS="${{ matrix.cflags }}" \
+            -D GRAPHICS=GRAPHICS_API_OPENGL_43
           cmake --build build --config Release
 
       - name: upload build
@@ -156,7 +158,9 @@ jobs:
             -D CMAKE_BUILD_TYPE=Release \
             -D CMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} \
             -D BUILD_SHARED_LIBS=ON \
-            -D BUILD_EXAMPLES=OFF
+            -D BUILD_EXAMPLES=OFF \
+            -D CMAKE_C_FLAGS="${{ matrix.cflags }}" \
+            -D GRAPHICS=GRAPHICS_API_OPENGL_43
           cmake --build build --config Release
 
       - name: upload build
@@ -190,7 +194,9 @@ jobs:
             -B build \
             -D CMAKE_BUILD_TYPE=Release \
             -D BUILD_SHARED_LIBS=ON \
-            -D BUILD_EXAMPLES=OFF
+            -D BUILD_EXAMPLES=OFF \
+            -D CMAKE_C_FLAGS="${{ matrix.cflags }}" \
+            -D GRAPHICS=GRAPHICS_API_OPENGL_43
           cmake --build build --config Release
 
       - name: upload build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,9 +159,10 @@ jobs:
             -D CMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} \
             -D BUILD_SHARED_LIBS=ON \
             -D BUILD_EXAMPLES=OFF \
-            -D CMAKE_C_FLAGS="${{ matrix.cflags }}" \
+            -D CMAKE_C_FLAGS="${{ matrix.cflags }} -Wno-dev" \
+            -D CMAKE_CXX_FLAGS="${{ matrix.cflags }} -Wno-dev" \
             -D GRAPHICS=GRAPHICS_API_OPENGL_43
-          cmake --build build --config Release -Wno-dev
+          cmake --build build --config Release
 
       - name: upload build
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This PR enables the Desktop platform to operate seamlessly with `OpenGL-4.3`.

Info:
Windows: `OpenGL-4.3`
Linux: `OpenGL-4.3`
Osx: `OpenGL-3.3`
Android: `OpenGL-ES 2.0`