### PR TITLE
Revert default graphics version change

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,6 @@ jobs:
             -D BUILD_SHARED_LIBS=ON \
             -D BUILD_EXAMPLES=OFF \
             -D CMAKE_C_FLAGS="${{ matrix.cflags }}" \
-            -D GRAPHICS=GRAPHICS_API_OPENGL_43
           cmake --build build --config Release
 
       - name: upload build
@@ -193,8 +192,7 @@ jobs:
             -D CMAKE_BUILD_TYPE=Release \
             -D BUILD_SHARED_LIBS=ON \
             -D BUILD_EXAMPLES=OFF \
-            -D CMAKE_C_FLAGS="${{ matrix.cflags }}" \
-            -D GRAPHICS=GRAPHICS_API_OPENGL_43
+            -D CMAKE_C_FLAGS="${{ matrix.cflags }}"
           cmake --build build --config Release
 
       - name: upload build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
             -D CMAKE_BUILD_TYPE=Release \
             -D BUILD_SHARED_LIBS=ON \
             -D BUILD_EXAMPLES=OFF \
-            -D CMAKE_C_FLAGS="${{ matrix.cflags }}" \
+            -D CMAKE_C_FLAGS="${{ matrix.cflags }}"
           cmake --build build --config Release
 
       - name: upload build

--- a/Raylib-cs.Native/Raylib-cs.Native.csproj
+++ b/Raylib-cs.Native/Raylib-cs.Native.csproj
@@ -33,6 +33,7 @@
     <CMakeArgs Include="-D CMAKE_BUILD_TYPE=$(Configuration)" />
     <CMakeArgs Include="-D BUILD_SHARED_LIBS=ON" />
     <CMakeArgs Include="-D BUILD_EXAMPLES=OFF" />
+    <!-- <CMakeArgs Include="-D GRAPHICS=GRAPHICS_API_OPENGL_43" /> -->
   </ItemGroup>
 
   <Target Name="ConfigureNative" BeforeTargets="BuildNative" Condition="$(SkipLocalBuild) != true">


### PR DESCRIPTION
Looking more into it, the default version change would cause issues with older GPUs. Decided instead to remove for now and leave a flag for it that can be commented out in the native project for further testing.