### PR TITLE
Pin to Ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       version: ${{ steps.version.outputs.version }}
       pkgversion: ${{ steps.version.outputs.pkgversion }}
@@ -50,7 +50,7 @@ jobs:
           echo "pkgversion=$(sed -n 's/.*<PackageVersion>\(.*\)<\/PackageVersion>.*/\1/p' Raylib-cs/Build.props)">> ${GITHUB_OUTPUT}
 
   build-android:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build
     strategy:
       matrix:
@@ -97,7 +97,7 @@ jobs:
           if-no-files-found: error
 
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build
     steps:
       - name: setup dependencies
@@ -203,7 +203,7 @@ jobs:
           if-no-files-found: error
 
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - build
       - build-android


### PR DESCRIPTION
Moves the GitHub Action to the latest Ubuntu LTS (`20.04`) to give wider compatibility.

Closes https://github.com/ChrisDill/Raylib-cs/issues/222