### PR TITLE
Add Example for Serilog as TraceLogCallback

### DIFF
--- a/Examples.Logging/CustomSerilogLogging.cs
+++ b/Examples.Logging/CustomSerilogLogging.cs
@@ -1,0 +1,66 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Serilog;
+using static Raylib_cs.Raylib;
+
+namespace Examples.Logging;
+
+public static class CustomSerilogLogging
+{
+    private static readonly ILogger Logger = new LoggerConfiguration()
+        .WriteTo.Console()
+        .CreateLogger();
+
+    private static unsafe delegate* unmanaged[Cdecl]<int, sbyte*, sbyte*, void> GetPointer() => &LogCallback;
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    public static unsafe void LogCallback(int msgType, sbyte* text, sbyte* args) {
+        // Retrieve the log message from Raylib
+        string message = Raylib_cs.Logging.GetLogMessage(new IntPtr(text), new IntPtr(args));
+
+        // Handle the message through Serilog
+        Logger.Information(message);
+    }
+
+    public static int Main()
+    {
+        Logger.Information("Using Serilog");
+
+        // Attach Logger to callback
+        //--------------------------------------------------------------------------------------
+        unsafe {
+            SetTraceLogCallback(GetPointer());
+        }
+
+        Logger.Information("Logger has been set to Raylib-cs TraceLogCallback");
+
+        // raylib Window Initialization
+        //--------------------------------------------------------------------------------------
+        const int screenWidth = 800;
+        const int screenHeight = 450;
+
+        InitWindow(screenWidth, screenHeight, "raylib custom Logger example - basic window");
+
+        // Main game loop
+        while (!WindowShouldClose())
+        {
+            // Draw
+            //----------------------------------------------------------------------------------
+            BeginDrawing();
+            ClearBackground(Color.RayWhite);
+
+            DrawText("Hello World!", 190, 200, 20, Color.Black);
+
+            EndDrawing();
+            //----------------------------------------------------------------------------------
+        }
+
+        // De-Initialization
+        //--------------------------------------------------------------------------------------
+        CloseWindow();
+        //--------------------------------------------------------------------------------------
+
+        return 0;
+    }
+}
+

--- a/Examples.Logging/CustomSerilogLogging.cs
+++ b/Examples.Logging/CustomSerilogLogging.cs
@@ -1,7 +1,7 @@
 ﻿using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Raylib_cs;
 using Serilog;
-using static Raylib_cs.Raylib;
 
 namespace Examples.Logging;
 
@@ -29,7 +29,7 @@ public static class CustomSerilogLogging
         // Attach Logger to callback
         //--------------------------------------------------------------------------------------
         unsafe {
-            SetTraceLogCallback(GetPointer());
+            Raylib.SetTraceLogCallback(GetPointer());
         }
 
         Logger.Information("Logger has been set to Raylib-cs TraceLogCallback");
@@ -39,25 +39,25 @@ public static class CustomSerilogLogging
         const int screenWidth = 800;
         const int screenHeight = 450;
 
-        InitWindow(screenWidth, screenHeight, "raylib custom Logger example - basic window");
+        Raylib.InitWindow(screenWidth, screenHeight, "raylib custom Logger example - basic window");
 
         // Main game loop
-        while (!WindowShouldClose())
+        while (!Raylib.WindowShouldClose())
         {
             // Draw
             //----------------------------------------------------------------------------------
-            BeginDrawing();
-            ClearBackground(Color.RayWhite);
+            Raylib.BeginDrawing();
+            Raylib.ClearBackground(Color.RayWhite);
 
-            DrawText("Hello World!", 190, 200, 20, Color.Black);
+            Raylib.DrawText("Hello World!", 190, 200, 20, Color.Black);
 
-            EndDrawing();
+            Raylib.EndDrawing();
             //----------------------------------------------------------------------------------
         }
 
         // De-Initialization
         //--------------------------------------------------------------------------------------
-        CloseWindow();
+        Raylib.CloseWindow();
         //--------------------------------------------------------------------------------------
 
         return 0;

--- a/Examples.Logging/Examples.Logging.csproj
+++ b/Examples.Logging/Examples.Logging.csproj
@@ -8,21 +8,13 @@
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
-    <ItemGroup>
-        <Compile Remove="Core/LoadingThread.cs"/>
-        <Compile Remove="Text/Unicode.cs"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <Using Include="Raylib_cs" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="../Raylib-cs/Raylib-cs.csproj" />
+<!--    <ItemGroup>-->
+<!--        <ProjectReference Include="../Raylib-cs/Raylib-cs.csproj" />-->
 <!--        <ProjectReference Include="../Raylib-cs.Native/Raylib-cs.Native.csproj" />-->
-    </ItemGroup>
+<!--    </ItemGroup>-->
 
     <ItemGroup>
+      <PackageReference Include="Raylib-cs" Version="6.0.0" />
       <PackageReference Include="Serilog" Version="3.1.1" />
       <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
     </ItemGroup>

--- a/Examples.Logging/Examples.Logging.csproj
+++ b/Examples.Logging/Examples.Logging.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <LangVersion>12</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Remove="Core/LoadingThread.cs"/>
+        <Compile Remove="Text/Unicode.cs"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Raylib_cs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="../Raylib-cs/Raylib-cs.csproj" />
+<!--        <ProjectReference Include="../Raylib-cs.Native/Raylib-cs.Native.csproj" />-->
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Serilog" Version="3.1.1" />
+      <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+    </ItemGroup>
+</Project>

--- a/Raylib-cs.sln
+++ b/Raylib-cs.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Raylib-cs.Tests", "Raylib-c
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Examples", "Examples\Examples.csproj", "{1E2A5986-3F11-457F-AF97-D0C08D0060BA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Examples.Logging", "Examples.Logging\Examples.Logging.csproj", "{5081623C-4756-4AF0-A0CC-61FE394FF7B2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{1E2A5986-3F11-457F-AF97-D0C08D0060BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1E2A5986-3F11-457F-AF97-D0C08D0060BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1E2A5986-3F11-457F-AF97-D0C08D0060BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5081623C-4756-4AF0-A0CC-61FE394FF7B2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5081623C-4756-4AF0-A0CC-61FE394FF7B2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5081623C-4756-4AF0-A0CC-61FE394FF7B2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5081623C-4756-4AF0-A0CC-61FE394FF7B2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
**Why?**
For my own project I wanted to set Serilog as the logging callback of Raylib-cs, though I couldn't find a proper example how to do it.
I didn't want to add it to the default `Examples` project, as I needed a dependency of `Serilog` for the example to work.
Serilog, or other loggers, are used to store logs to other endpoints than just the Console.


**Addendum**
This is my 'end of day' when I write this, and I haven't been able to figure out how to get `Raylib-cs.Native` to work in Jetbrains Rider so I can't test within the project, hense the reason for the Draft status