### PR TITLE
Safe UpdateMeshBuffer Util Method

### DIFF
--- a/Examples/Models/DynamicMesh.cs
+++ b/Examples/Models/DynamicMesh.cs
@@ -1,0 +1,127 @@
+using System.Numerics;
+using static Raylib_cs.Raylib;
+
+namespace Examples.Models;
+
+public class DynamicMesh
+{
+    public unsafe static int Main()
+    {
+        // Initialization
+        //--------------------------------------------------------------------------------------
+        const int screenWidth = 800;
+        const int screenHeight = 450;
+
+        InitWindow(screenWidth, screenHeight, "raylib [models] example - dynamic mesh");
+
+        // Define the camera to look into our 3d world
+        Camera3D camera = new();
+        camera.Position = Vector3.One * 1.5f;
+        camera.Target = camera.Position + new Vector3(1f, -0.25f, 1f);
+        camera.Up = Vector3.UnitY;
+        camera.FovY = 60.0f;
+        camera.Projection = CameraProjection.Perspective;
+
+        // Generate a dynamic mesh using utils to allocate/access mesh attribute data
+        const int triangleRows = 48;
+        const int vertexRows = triangleRows + 1;
+        Mesh dynamicMesh = new(vertexRows * vertexRows, triangleRows * triangleRows * 2);
+        dynamicMesh.AllocVertices();
+        dynamicMesh.AllocTexCoords();
+        dynamicMesh.AllocIndices();
+        Span<Vector3> vertices = dynamicMesh.VerticesAs<Vector3>();
+        Span<Vector2> texcoords = dynamicMesh.TexCoordsAs<Vector2>();
+        Span<ushort> indices = dynamicMesh.IndicesAs<ushort>();
+        for (int z = 0, i = 0; z < triangleRows; z++)
+        {
+            for (int x = 0; x < triangleRows; x++, i += 6)
+            {
+                indices[i + 0] = (ushort)(x + (z * vertexRows));
+                indices[i + 1] = (ushort)(indices[i] + vertexRows);
+                indices[i + 2] = (ushort)(indices[i] + 1);
+                indices[i + 3] = (ushort)(indices[i] + 1);
+                indices[i + 4] = (ushort)(indices[i] + vertexRows);
+                indices[i + 5] = (ushort)(indices[i] + vertexRows + 1);
+            }
+        }
+        UploadMesh(ref dynamicMesh, true);
+
+        // Allocate the texture
+        Image image = GenImageColor(triangleRows, triangleRows, Color.Blank);
+        Texture2D texture = LoadTextureFromImage(image);
+        Color[] pixels = new Color[texture.Width * texture.Height];
+        UnloadImage(image);
+
+        // Load the material
+        Material material = LoadMaterialDefault();
+        SetMaterialTexture(ref material, MaterialMapIndex.Diffuse, texture);
+
+        SetTargetFPS(60);
+        //--------------------------------------------------------------------------------------
+
+        // Main game loop
+        while (!WindowShouldClose())
+        {
+            // Update
+            //----------------------------------------------------------------------------------
+            float time = (float)GetTime();
+            Random random = new(42);
+
+            for (int z = 0, i = 0; z < vertexRows; z++)
+            {
+                for (int x = 0; x < vertexRows; x++, i++)
+                {
+                    float noiseX = SmoothNoise(time + random.Next(10000));
+                    float noiseZ = SmoothNoise(time + random.Next(10000));
+                    vertices[i].X = x + noiseX - .5f;
+                    vertices[i].Y = (noiseX + noiseZ) / 2;
+                    vertices[i].Z = z + noiseZ - .5f;
+                    texcoords[i].X = (x - noiseZ) / triangleRows;
+                    texcoords[i].Y = (z - noiseX) / triangleRows;
+                }
+            }
+            UpdateMeshBuffer<Vector3>(dynamicMesh, Mesh.VboIdIndexVertices, vertices, 0);
+            UpdateMeshBuffer<Vector2>(dynamicMesh, Mesh.VboIdIndexTexCoords, texcoords, 0);
+
+            for (int y = 0, i = 0; y < texture.Height; y++)
+            {
+                for (int x = 0; x < texture.Width; x++, i++)
+                {
+                    pixels[i] = new(32, 178, 170, 255);
+                    pixels[i] = ColorBrightness(pixels[i], (SmoothNoise(time + random.Next(10000)) / 8) - (1 / 16f));
+                    pixels[i] = ColorAlpha(pixels[i], (triangleRows - new Vector2(x, y).Length()) / triangleRows);
+                }
+            }
+            UpdateTexture(texture, pixels);
+            //----------------------------------------------------------------------------------
+
+            // Draw
+            //----------------------------------------------------------------------------------
+            BeginDrawing();
+            ClearBackground(Color.RayWhite);
+
+            BeginMode3D(camera);
+            DrawMesh(dynamicMesh, material, Matrix4x4.Identity);
+            EndMode3D();
+
+            EndDrawing();
+            //----------------------------------------------------------------------------------
+        }
+
+        // De-Initialization
+        //--------------------------------------------------------------------------------------
+        UnloadMaterial(material);
+        // Raylib.UnloadTexture(texture); <- No need to unload the texture. UnloadMaterial(Material) already unloaded it for us
+        UnloadMesh(dynamicMesh);
+
+        CloseWindow();
+        //--------------------------------------------------------------------------------------
+
+        return 0;
+    }
+
+    private static float SmoothNoise(float value)
+    {
+        return ((MathF.Sin(value) + MathF.Cos(value * MathF.E)) / 4) + .5f;
+    }
+}

--- a/Raylib-cs/types/Mesh.cs
+++ b/Raylib-cs/types/Mesh.cs
@@ -216,5 +216,40 @@ public unsafe partial struct Mesh
     /// </summary>
     public uint* VboId = default;
 
+    /// <summary>
+    /// Default <see cref="VboId"/> index for <see cref="Vertices"/>
+    /// </summary>
+    public const int VboIdIndexVertices = 0;
+
+    /// <summary>
+    /// Default <see cref="VboId"/> index for <see cref="TexCoords"/>
+    /// </summary>
+    public const int VboIdIndexTexCoords = 1;
+
+    /// <summary>
+    /// Default <see cref="VboId"/> index for <see cref="Normals"/>
+    /// </summary>
+    public const int VboIdIndexNormals = 2;
+
+    /// <summary>
+    /// Default <see cref="VboId"/> index for <see cref="Colors"/>
+    /// </summary>
+    public const int VboIdIndexColors = 3;
+
+    /// <summary>
+    /// Default <see cref="VboId"/> index for <see cref="Tangents"/>
+    /// </summary>
+    public const int VboIdIndexTangents = 4;
+
+    /// <summary>
+    /// Default <see cref="VboId"/> index for <see cref="TexCoords2"/>
+    /// </summary>
+    public const int VboIdIndexTexCoords2 = 5;
+
+    /// <summary>
+    /// Default <see cref="VboId"/> index for <see cref="Indices"/>
+    /// </summary>
+    public const int VboIdIndexIndices = 6;
+
     #endregion
 }

--- a/Raylib-cs/types/Raylib.Utils.cs
+++ b/Raylib-cs/types/Raylib.Utils.cs
@@ -911,6 +911,15 @@ public static unsafe partial class Raylib
         }
     }
 
+    /// <summary> Update mesh vertex data in GPU for a specific buffer index </summary>
+    public static void UpdateMeshBuffer<T>(Mesh mesh, int index, ReadOnlySpan<T> data, int offset) where T : unmanaged
+    {
+        fixed (void* dataPtr = data)
+        {
+            UpdateMeshBuffer(mesh, index, dataPtr, data.Length * sizeof(T), offset);
+        }
+    }
+
     /// <summary>Set texture for a material map type (MAP_DIFFUSE, MAP_SPECULAR...)</summary>
     public static void SetMaterialTexture(ref Material material, MaterialMapIndex mapType, Texture2D texture)
     {


### PR DESCRIPTION
The UpdateMeshBuffer Method is important for updating GPU mesh data repeatedly in a performant manner.

This pull request intends to add a safe utility version of this method by accepting a span wrapper of the data rather than a pointer.

This method (including the interop version) requires an index to whichever buffer the user wishes to update—for example vertices, texture coordinates, colors etcetera. This is why I added VboIdIndex<Type> constants to the mesh class to help users access the right vertex buffer object (VBO) ID for the UpdateMeshBuffer Method.

For whatever reason raysan5/raylib does not include an enum or definitions for these VBO indexes. The closest thing I could find to these indexes being defined anywhere was in the raylib source code in [UploadMesh](https://github.com/raysan5/raylib/blob/efce4d69ce913bca42289184b0bffe4339c0193f/src/rmodels.c#L1249-L1255).

I also added an example showing a good use case for the safe UpdateMeshBuffer Method and the VBO definitions.
Here is what you should expect from the example program:
![ezgif-1-5eb15b5140](https://github.com/user-attachments/assets/a0b625a6-26ec-4456-af52-3349b983508c)