### PR TITLE
Remove package System.Numerics.Vectors

### DIFF
--- a/Raylib-cs/Raylib-cs.csproj
+++ b/Raylib-cs/Raylib-cs.csproj
@@ -33,8 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Numerics.Vectors" Version="4.6.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <Import Project="./Build.props" />


### PR DESCRIPTION
This package is no longer required, because it's part of the standard library now.